### PR TITLE
Improvement/increase snackbar coverage

### DIFF
--- a/packages/sling-web-component-snackbar/src/component/SnackBar.js
+++ b/packages/sling-web-component-snackbar/src/component/SnackBar.js
@@ -45,7 +45,9 @@ export class SnackBar extends SlingElement {
       <div className="${className}">
         <sling-icon class="emd-snackbar_icon" icon="${this.aim || 'info'}"></sling-icon>
         <div class="emd-snackbar_list">
-          <div class="emd-snackbar_item"><slot></slot></div>
+          <div class="emd-snackbar_item">
+            <slot></slot>
+          </div>
         </div>
         ${this.closeable ? html`
           <sling-button layout="text" onclick="${this.handleClick}">

--- a/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
+++ b/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
@@ -17,31 +17,59 @@ describe('Snackbar', () => {
     $snackbar = undefined;
   });
 
-  it('Should reflect "brandid", "width" and "heigth" attribute to property ', () => {
+  it('Should reflect "layout" attribute to property ', () => {
     $snackbar.setAttribute('layout', 'outline');
-    $snackbar.setAttribute('aim', 'danger');
-    $snackbar.setAttribute('size', 'small');
-    $snackbar.setAttribute('closeable', '');
+    expect($snackbar.layout).to.equal('outline');
+  });
 
-    expect($snackbar.layout).to.equal('outline')
-    expect($snackbar.aim).to.equal('danger')
-    expect($snackbar.size).to.equal('small')
-    expect($snackbar.closeable).to.be.true
-  })
-
-  it('Should reflect "layout", "aim" and "heigth" property to attribute ', (done) => {
+  it('Should reflect "layout" property to attribute ', (done) => {
     $snackbar.layout = 'outline';
+
+    setTimeout(() => {
+      expect($snackbar.getAttribute('layout')).to.equal('outline');
+      done();
+    });
+  });
+
+  it('Should reflect "aim" attribute to property ', () => {
+    $snackbar.setAttribute('aim', 'danger');
+    expect($snackbar.aim).to.equal('danger');
+  });
+
+  it('Should reflect "aim" property to attribute ', (done) => {
     $snackbar.aim = 'warning';
+
+    setTimeout(() => {
+      expect($snackbar.getAttribute('aim')).to.equal('warning');
+      done();
+    });
+  });
+
+  it('Should reflect "size" attribute to property ', () => {
+    $snackbar.setAttribute('size', 'small');
+    expect($snackbar.size).to.equal('small');
+  });
+
+  it('Should reflect "size" property to attribute ', (done) => {
     $snackbar.size = 'big';
+
+    setTimeout(() => {
+      expect($snackbar.getAttribute('size')).to.equal('big');
+      done();
+    });
+  });
+
+  it('Should reflect "closeable" attribute to property ', () => {
+    $snackbar.setAttribute('closeable', '');
+    expect($snackbar.closeable).to.be.true;
+  });
+
+  it('Should reflect "closeable" property to attribute ', (done) => {
     $snackbar.closeable = null;
 
     setTimeout(() => {
-      expect($snackbar.getAttribute('layout')).to.equal('outline')
-      expect($snackbar.getAttribute('aim')).to.equal('warning')
-      expect($snackbar.getAttribute('size')).to.equal('big')
-      expect($snackbar.getAttribute('closeable')).to.be.null
-      done()
-    })
-  })
-
+      expect($snackbar.getAttribute('closeable')).to.be.null;
+      done();
+    });
+  });
 });

--- a/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
+++ b/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { spy } from 'sinon';
 import { registerComponent } from 'sling-helpers';
 import { SnackBar } from './SnackBar.js';
 
@@ -17,59 +18,106 @@ describe('Snackbar', () => {
     $snackbar = undefined;
   });
 
-  it('Should reflect "layout" attribute to property ', () => {
-    $snackbar.setAttribute('layout', 'outline');
-    expect($snackbar.layout).to.equal('outline');
-  });
+  describe('Reflection', () => {
+    it('Should reflect "layout" attribute to property ', () => {
+      $snackbar.setAttribute('layout', 'outline');
+      expect($snackbar.layout).to.equal('outline');
+    });
 
-  it('Should reflect "layout" property to attribute ', (done) => {
-    $snackbar.layout = 'outline';
+    it('Should reflect "layout" property to attribute ', (done) => {
+      $snackbar.layout = 'outline';
 
-    setTimeout(() => {
-      expect($snackbar.getAttribute('layout')).to.equal('outline');
-      done();
+      setTimeout(() => {
+        expect($snackbar.getAttribute('layout')).to.equal('outline');
+        done();
+      });
+    });
+
+    it('Should reflect "aim" attribute to property ', () => {
+      $snackbar.setAttribute('aim', 'danger');
+      expect($snackbar.aim).to.equal('danger');
+    });
+
+    it('Should reflect "aim" property to attribute ', (done) => {
+      $snackbar.aim = 'warning';
+
+      setTimeout(() => {
+        expect($snackbar.getAttribute('aim')).to.equal('warning');
+        done();
+      });
+    });
+
+    it('Should reflect "size" attribute to property ', () => {
+      $snackbar.setAttribute('size', 'small');
+      expect($snackbar.size).to.equal('small');
+    });
+
+    it('Should reflect "size" property to attribute ', (done) => {
+      $snackbar.size = 'big';
+
+      setTimeout(() => {
+        expect($snackbar.getAttribute('size')).to.equal('big');
+        done();
+      });
+    });
+
+    it('Should reflect "closeable" attribute to property ', () => {
+      $snackbar.setAttribute('closeable', '');
+      expect($snackbar.closeable).to.be.true;
+    });
+
+    it('Should reflect "closeable" property to attribute ', (done) => {
+      $snackbar.closeable = null;
+
+      setTimeout(() => {
+        expect($snackbar.getAttribute('closeable')).to.be.null;
+        done();
+      });
     });
   });
 
-  it('Should reflect "aim" attribute to property ', () => {
-    $snackbar.setAttribute('aim', 'danger');
-    expect($snackbar.aim).to.equal('danger');
-  });
+  describe('Content rendering', () => {
+    it('Should use "info" icon if "aim" attribute is omitted', () => {
+      const $icon = $snackbar.shadowRoot.querySelector('sling-icon');
+      expect($icon.icon).to.equal('info');
+    });
 
-  it('Should reflect "aim" property to attribute ', (done) => {
-    $snackbar.aim = 'warning';
+    it('Should reflect to icon when "aim" is provided', (done) => {
+      $snackbar.aim = 'danger';
 
-    setTimeout(() => {
-      expect($snackbar.getAttribute('aim')).to.equal('warning');
-      done();
+      setTimeout(() => {
+        const $icon = $snackbar.shadowRoot.querySelector('sling-icon');
+        expect($icon.icon).to.equal('danger');
+        done();
+      });
+    });
+
+    it('Should NOT render a close button when "closeable" is omitted', () => {
+      expect($snackbar.shadowRoot.querySelector('sling-button')).to.not.exist;
+    });
+
+    it('Should render a close button when "closeable" is provided', (done) => {
+      $snackbar.closeable = true;
+
+      setTimeout(() => {
+        expect($snackbar.shadowRoot.querySelector('sling-button')).to.exist;
+        done();
+      });
     });
   });
 
-  it('Should reflect "size" attribute to property ', () => {
-    $snackbar.setAttribute('size', 'small');
-    expect($snackbar.size).to.equal('small');
-  });
+  describe('Handlers', () => {
+    it('Should call "closeclick" handler when close button is clicked', (done) => {
+      $snackbar.closeable = true;
 
-  it('Should reflect "size" property to attribute ', (done) => {
-    $snackbar.size = 'big';
+      setTimeout(() => {
+        const handler = spy();
+        $snackbar.addEventListener('closeclick', handler);
+        $snackbar.shadowRoot.querySelector('sling-button').click();
 
-    setTimeout(() => {
-      expect($snackbar.getAttribute('size')).to.equal('big');
-      done();
-    });
-  });
-
-  it('Should reflect "closeable" attribute to property ', () => {
-    $snackbar.setAttribute('closeable', '');
-    expect($snackbar.closeable).to.be.true;
-  });
-
-  it('Should reflect "closeable" property to attribute ', (done) => {
-    $snackbar.closeable = null;
-
-    setTimeout(() => {
-      expect($snackbar.getAttribute('closeable')).to.be.null;
-      done();
+        expect(handler.calledOnce).to.be.true;
+        done();
+      });
     });
   });
 });

--- a/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
+++ b/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { spy } from 'sinon';
 import { registerComponent } from 'sling-helpers';
 import { SnackBar } from './SnackBar.js';

--- a/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
+++ b/packages/sling-web-component-snackbar/src/component/SnackBar.test.js
@@ -106,7 +106,8 @@ describe('Snackbar', () => {
   });
 
   describe('Handlers', () => {
-    it('Should call "closeclick" handler when close button is clicked', (done) => {
+    it('Should call "closeclick" handler when close '
+      + 'button is clicked', (done) => {
       $snackbar.closeable = true;
 
       setTimeout(() => {


### PR DESCRIPTION
#### Related issue
Fixes #21 

#### Short description of what this resolves:
This PR adds a few more test cases to the `Snackbar` component and increases its coverage to 100% ( 🎉). Also, took the opportunity to test the reflections separately, having each property being tested in a different `it` block.