### PR TITLE
feat: Update karma to use Puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.8",
     "@semantic-release/changelog": "^3.0.0",
-    "@semantic-release/git": "^7.0.4"
+    "@semantic-release/git": "^7.0.4",
+    "puppeteer": "^1.9.0"
   },
   "release": {
     "branch": "next"

--- a/scripts/config/karma.conf.js
+++ b/scripts/config/karma.conf.js
@@ -4,6 +4,8 @@ const getBasePath = require('../helpers/getBasePath');
 const basePath = getBasePath();
 const allPackagesPath = './packages/*';
 
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 let reports = {
   reporters: ['mocha'],
   mochaReporter: {


### PR DESCRIPTION
#### Short description of what this resolves:
Makes Karma independent of the current chrome instance installed on the developer machine

#### Changes proposed in this pull request:
- Adds puppeteer dependence
- Set karma to use it as `CHROME_BIN` executable
