### PR TITLE
Fix typos on documentation

### DIFF
--- a/packages/sling-web-component-brand-icon/README.md
+++ b/packages/sling-web-component-brand-icon/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-brand-icon
+npm install sling-web-component-brand-icon
 ```
 
 ## Tag

--- a/packages/sling-web-component-button/README.md
+++ b/packages/sling-web-component-button/README.md
@@ -3,7 +3,7 @@
 ## Install      
 
 ```
-npm instal sling-web-component-button
+npm install sling-web-component-button
 ```
  
  ## Tag

--- a/packages/sling-web-component-calendar/README.md
+++ b/packages/sling-web-component-calendar/README.md
@@ -5,7 +5,7 @@ The calendar component is a simple and customizable calendar that receives an ar
  
 ## Install      
 ```
-npm instal sling-web-component-calendar
+npm install sling-web-component-calendar
 ```
   
 ## Tag

--- a/packages/sling-web-component-card/README.md
+++ b/packages/sling-web-component-card/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-card
+npm install sling-web-component-card
 ```
 
 ## Tag

--- a/packages/sling-web-component-form/README.md
+++ b/packages/sling-web-component-form/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-form
+npm install sling-web-component-form
 ```
 
 ## Tag

--- a/packages/sling-web-component-icon/README.md
+++ b/packages/sling-web-component-icon/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-icon
+npm install sling-web-component-icon
 ```
 
 ## Tag

--- a/packages/sling-web-component-input/README.md
+++ b/packages/sling-web-component-input/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-input 
+npm install sling-web-component-input 
 ```  
 
 ## Tag

--- a/packages/sling-web-component-label/README.md
+++ b/packages/sling-web-component-label/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-label
+npm install sling-web-component-label
 ```
 
 ## Tag

--- a/packages/sling-web-component-list/README.md
+++ b/packages/sling-web-component-list/README.md
@@ -5,7 +5,7 @@ Sling Card Basic Component.
 ## Install
 
 ```
-npm instal sling-web-component-list
+npm install sling-web-component-list
 ```
 
 ## Tag

--- a/packages/sling-web-component-loader-wrapper/README.md
+++ b/packages/sling-web-component-loader-wrapper/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-loader-wrapper
+npm install sling-web-component-loader-wrapper
 ```
 
 ## Tag

--- a/packages/sling-web-component-loader/README.md
+++ b/packages/sling-web-component-loader/README.md
@@ -6,7 +6,7 @@ The component must show the loader component while loading the data source requi
 ## Install
 
 ```
-npm instal sling-web-component-loader
+npm install sling-web-component-loader
 ```
 
 ## Tag

--- a/packages/sling-web-component-login/README.md
+++ b/packages/sling-web-component-login/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-login
+npm install sling-web-component-login
 ```
 
 ## Tag

--- a/packages/sling-web-component-message/README.md
+++ b/packages/sling-web-component-message/README.md
@@ -5,7 +5,7 @@ The message component is a static bar that indicates, through prevailing icons a
 ## Install
 
 ```
-npm instal sling-web-component-message
+npm install sling-web-component-message
 ```
 
 ## Tag

--- a/packages/sling-web-component-paginator/README.md
+++ b/packages/sling-web-component-paginator/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-paginator
+npm install sling-web-component-paginator
 ```
 
 ## Tag

--- a/packages/sling-web-component-sdk-connect/README.md
+++ b/packages/sling-web-component-sdk-connect/README.md
@@ -3,7 +3,7 @@
 ## Install      
 
 ```
-npm instal sling-web-component-sdk-connect
+npm install sling-web-component-sdk-connect
 ```
  
  ## Tag

--- a/packages/sling-web-component-select/README.md
+++ b/packages/sling-web-component-select/README.md
@@ -3,7 +3,7 @@
 ## Install      
 
 ```
-npm instal sling-web-component-select
+npm install sling-web-component-select
 ```
  
  ## Tag

--- a/packages/sling-web-component-snackbar/README.md
+++ b/packages/sling-web-component-snackbar/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-snackbar
+npm install sling-web-component-snackbar
 ```
 
 ## Tag

--- a/packages/sling-web-component-table/README.md
+++ b/packages/sling-web-component-table/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```
-npm instal sling-web-component-table
+npm install sling-web-component-table
 ```
 
  ## Tag

--- a/packages/sling-web-component-tooltip/README.md
+++ b/packages/sling-web-component-tooltip/README.md
@@ -5,7 +5,7 @@ The tooltip component is a simple and customizable tooltip that receives an text
  
 ## Install      
 ```
-npm instal sling-web-component-tooltip
+npm install sling-web-component-tooltip
 ```
   
 ## Tag


### PR DESCRIPTION
#### Short description of what this resolves:
Command line typos.
fixes #109 

#### Changes proposed in this pull request:

- To fix the spelling of the word "install" in components' guides.
