### PR TITLE
fix(sling-input): Phone Mask issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # lerna
 lerna-debug.log
+
+#selenium
+/bin

--- a/packages/sling-web-component-input/src/component/Input.js
+++ b/packages/sling-web-component-input/src/component/Input.js
@@ -133,13 +133,13 @@ export class Input extends SlingElement {
               mask: '(00) 00000-0000',
             }],
             dispatch(appended, dynamicMasked) {
-              if (appended.length < 15) {
+              if ((dynamicMasked.value + appended).length < 15) {
                 return dynamicMasked.compiledMasks[0];
               }
               return dynamicMasked.compiledMasks[1];
             },
           });
-          this.maxlength = 15;
+          this.maxlength = 16;
           break;
         }
         case 'cep': {


### PR DESCRIPTION
#### Short description of what this resolves:
Now the mask work as expected, no matter how many digits a phone have