### PR TITLE
Clean previous request errors when making a new request

### DIFF
--- a/packages/sling-framework/src/v1/src/business/withLoadingAndErrorHandling.js
+++ b/packages/sling-framework/src/v1/src/business/withLoadingAndErrorHandling.js
@@ -43,6 +43,7 @@ export const withLoadingAndErrorHandling = (Base = class {}) =>
     }
 
     request(oneOrManyRequests) {
+      this.requestErrors = [];
       const requestSingle = this.requestSingle.bind(this);
 
       if (Array.isArray(oneOrManyRequests)) {


### PR DESCRIPTION
#### Short description of what this resolves:

When using `withRequest` on new business components, eventual request errors won't be cleaned after trying a new request. This PR fixes that.
