### PR TITLE
Fix/TypeError: Cannot read property 'get' of undefined

### DIFF
--- a/packages/sling-helpers/src/dom/domHelper.js
+++ b/packages/sling-helpers/src/dom/domHelper.js
@@ -36,7 +36,7 @@ export const waitUntilTagIsAppended = (name, domEl) =>
   });
 
 export const registerComponent = (name, DefinitionClass) => {
-  if (window.customElements.get(name) == null) {
+  if (window.customElements && window.customElements.get(name) == null) {
     window.customElements.define(name, DefinitionClass);
   }
 };


### PR DESCRIPTION
#### Short description of what this resolves:
- I was receiving this error while running tests inside my own project:

```bash
sling-helpers/dist/cjs/es5/dom/domHelper.js:58
  if (window.customElements.get(name) == null) {
                            ^

TypeError: Cannot read property 'get' of undefined
```


#### Changes proposed in this pull request:

- Fix the above error.